### PR TITLE
feat: 運勢歷史頁面 RWD 優化 + 日期時區修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,17 @@
 <!-- OPENSPEC:START -->
+
 # OpenSpec Instructions
 
 These instructions are for AI assistants working in this project.
 
 Always open `@/openspec/AGENTS.md` when the request:
+
 - Mentions planning or proposals (words like proposal, spec, change, plan)
 - Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
 - Sounds ambiguous and you need the authoritative spec before coding
 
 Use `@/openspec/AGENTS.md` to learn:
+
 - How to create and apply change proposals
 - Spec format and conventions
 - Project structure and guidelines
@@ -20,6 +23,7 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 # Project State
 
 ## Completed
+
 - **Step 1**: OpenCode config (opencode.json, tools)
 - **Step 2**: Base optimizations (dashboard, apiCache, errorHandler, analytics)
 - **Step 3**: IndexedDB history store (types, fortuneStore, 100-record in-memory cache, dedup by date+userProfileHash)
@@ -30,23 +34,27 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 - **Step 8**: Final UI Polish & Consistency Pass — All 4 main pages unified layout (full-width cards, responsive spacing), 195 tests pass ✅
 
 ## Routes
-| Path | Name | NavBar |
-|------|------|--------|
-| `/` | home | 首頁 |
-| `/dashboard` | dashboard | 投資儀表板 |
-| `/history` | history | 運勢歷史 |
-| `/analytics` | analytics | 數據分析 |
-| `/profile` | profile | 個人設定 |
-| `/dev/perf` | perf-monitor | ❌ 隱藏 |
-| `/dev/api` | api-monitor | ❌ 隱藏 |
+
+| Path         | Name         | NavBar     |
+| ------------ | ------------ | ---------- |
+| `/`          | home         | 首頁       |
+| `/dashboard` | dashboard    | 投資儀表板 |
+| `/history`   | history      | 運勢歷史   |
+| `/analytics` | analytics    | 數據分析   |
+| `/profile`   | profile      | 個人設定   |
+| `/dev/perf`  | perf-monitor | ❌ 隱藏    |
+| `/dev/api`   | api-monitor  | ❌ 隱藏    |
 
 ## Dev Tools Access
+
 - Performance monitor: `window.__perfMonitor.start(label)`, `window.__perfMonitor.end(label)` then navigate to `/dev/perf`
 - API monitor: `window.__apiMonitor.record(endpoint, method, status, duration)` then navigate to `/dev/api`
 
 ## Tests
-- 196 tests across 13 test files
-- Key: `fortuneStore.test.ts` (12), `fortuneLogViewer.test.ts` (6), `dashboard.test.ts` (18), `analytics.test.ts` (17), `user.test.ts` (15)
+
+- 198 tests across 13 test files
+- Key: `fortuneStore.test.ts` (12), `fortuneLogViewer.test.ts` (8), `dashboard.test.ts` (18), `analytics.test.ts` (17), `user.test.ts` (15)
 
 ## Tech Stack
+
 Vue 3.5 + TypeScript 5.9 + Vite 8.1 + Pinia 3.0 + TailwindCSS 3.3 + Vitest 4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,59 +1,90 @@
 # Changelog
 
+## [2026-07-11] 運勢歷史頁面 RWD 優化 + 日期時區修正
+
+### FortuneLogViewer 重構 (`src/components/FortuneLogViewer.vue`)
+
+- 手機版記錄從水平列表改為**獨立卡片佈局**，垂直堆疊更易閱讀
+- 篩選面板手機版**預設收合**，點擊展開完整篩選工具
+- 手機版篩選摘要行顯示 active filter tags
+- `<select>` 下拉框改為 **filter chips**（買入/持有/賣出），toggle 切換
+- 新增**清除確認對話框**（Teleport + 遮罩），防止誤觸清除全部記錄
+- 載入中從「載入中...」文字改為 **skeleton pulse 動畫**（手機/桌面雙版本）
+- `clearFilters()` 恢復預設日期範圍（6 個月）而非空字串
+- 五行能量條在手機版改為水平排列 + 中文標籤（金木水火土）
+
+### 日期時區 Bug 修正
+
+- **根本原因**：`date.toISOString().split('T')[0]` 在 UTC+8 時區下將本地時間轉成 UTC，導致日期偏移一天
+- 新增 `src/utils/date.ts` — `toLocalDateString()` 使用 `getFullYear/getMonth/getDate` 取得本地日期
+- 修復 `fortune.ts`、`integratedFortune.ts`、`finmind.ts`、`dashboard.ts`、`Analytics.vue` 中所有 `toISOString().split('T')[0]` 呼叫
+- FortuneLogViewer 篩選器初始值改用 `toLocalDateString()`
+
+### 測試更新 (`src/tests/fortuneLogViewer.test.ts`)
+
+- 從 5 個測試擴充為 **8 個測試**
+- 新增：確認對話框顯示、確認後 emit、取消關閉對話框、skeleton 載入狀態
+- 選擇器從 `<select>` 改為 chip button 測試
+- 使用 `document.body` 存取 Teleport 渲染的對話框內容
+
 ## [2026-07-10] Vue 生態系大規模升級 (Phase 1-3)
 
 ### Phase 1: Core Vue
 
-| Package | Before | After |
-|---------|--------|-------|
-| vue | 3.5.22 | 3.5.39 |
-| vue-router | 4.5.1 | 5.1.0 |
-| pinia | 3.0.3 | 3.0.4 |
-| pinia-plugin-persistedstate | 4.5.0 | 4.7.1 |
-| vue-chartjs | 5.3.2 | 5.3.4 |
-| vue-tsc | 3.2.2 | 3.3.7 |
-| @vue/test-utils | 2.4.6 | 2.4.11 |
+| Package                     | Before | After  |
+| --------------------------- | ------ | ------ |
+| vue                         | 3.5.22 | 3.5.39 |
+| vue-router                  | 4.5.1  | 5.1.0  |
+| pinia                       | 3.0.3  | 3.0.4  |
+| pinia-plugin-persistedstate | 4.5.0  | 4.7.1  |
+| vue-chartjs                 | 5.3.2  | 5.3.4  |
+| vue-tsc                     | 3.2.2  | 3.3.7  |
+| @vue/test-utils             | 2.4.6  | 2.4.11 |
 
 **Vue Router 5 upgrade** (`src/router/index.ts`):
+
 - `beforeEach` guard 移除已棄用的 `next()` callback，改為直接 return
 
 ### Phase 2: Vite + Build Tools
 
-| Package | Before | After |
-|---------|--------|-------|
-| vite | 4.5.14 | 8.1.4 |
-| @vitejs/plugin-vue | 4.6.2 | 6.0.7 |
-| vitest | 4.0.17 | 4.1.10 |
-| @vitest/coverage-v8 | 4.0.17 | 4.1.10 |
-| @vitest/ui | 4.0.17 | 4.1.10 |
-| vite-plugin-pwa | 1.0.3 | 1.3.0 |
-| workbox-build | 7.3.0 | 7.4.1 |
-| workbox-window | 7.3.0 | 7.4.1 |
-| autoprefixer | 10.4.21 | 10.5.2 |
-| postcss | 8.5.6 | 8.5.16 |
-| terser | 5.44.0 | 5.49.0 |
+| Package             | Before  | After  |
+| ------------------- | ------- | ------ |
+| vite                | 4.5.14  | 8.1.4  |
+| @vitejs/plugin-vue  | 4.6.2   | 6.0.7  |
+| vitest              | 4.0.17  | 4.1.10 |
+| @vitest/coverage-v8 | 4.0.17  | 4.1.10 |
+| @vitest/ui          | 4.0.17  | 4.1.10 |
+| vite-plugin-pwa     | 1.0.3   | 1.3.0  |
+| workbox-build       | 7.3.0   | 7.4.1  |
+| workbox-window      | 7.3.0   | 7.4.1  |
+| autoprefixer        | 10.4.21 | 10.5.2 |
+| postcss             | 8.5.6   | 8.5.16 |
+| terser              | 5.44.0  | 5.49.0 |
 
 **Vite 8 breaking change** (`vite.config.ts`):
+
 - `rollupOptions.output.manualChunks` 從物件格式改為函數格式（rolldown 相容）
 
 ### Phase 3: ESLint 生態系
 
-| Package | Before | After |
-|---------|--------|-------|
-| eslint | 9.39.2 | 10.6.0 |
-| eslint-plugin-vue | 9.33.0 | 10.9.2 |
+| Package                          | Before | After  |
+| -------------------------------- | ------ | ------ |
+| eslint                           | 9.39.2 | 10.6.0 |
+| eslint-plugin-vue                | 9.33.0 | 10.9.2 |
 | @typescript-eslint/eslint-plugin | 8.53.0 | 8.63.0 |
-| @typescript-eslint/parser | 8.53.0 | 8.63.0 |
-| @vue/eslint-config-typescript | 14.6.0 | 14.9.0 |
-| @eslint/js (new) | — | 10.0.1 |
-| vue-eslint-parser (new) | — | 10.4.1 |
+| @typescript-eslint/parser        | 8.53.0 | 8.63.0 |
+| @vue/eslint-config-typescript    | 14.6.0 | 14.9.0 |
+| @eslint/js (new)                 | —      | 10.0.1 |
+| vue-eslint-parser (new)          | —      | 10.4.1 |
 
 **eslint-plugin-vue v10 新增規則** (`src/components/ErrorModal.vue`):
+
 - `vue/no-required-prop-with-default`: `modelValue` 和 `message` 改為 optional interface
 
 ### 其他修復
 
 **`index.html`**:
+
 - 加入 `meta[name="mobile-web-app-capable"]`（`apple-mobile-web-app-capable` 已棄用的替代）
 - 移除重複的 Google Fonts preload
 
@@ -67,26 +98,31 @@
 ## [2026-07-10] Step 5-7: History page + Dev tools
 
 ### Step 5 — History page
+
 - Created `src/views/History.vue` as a dedicated page wrapping `FortuneLogViewer`
 - Added `/history` route in `src/router/index.ts`
 - Added "運勢歷史" link to NavBar (desktop + mobile)
 - Removed inline `FortuneLogViewer` toggle from `Dashboard.vue`
 
 ### Step 6 — Performance monitor
+
 - Created `src/views/dev/PerformanceMonitor.vue` with record/stop/clear controls
 - Route at `/dev/perf` (name: `perf-monitor`), not in NavBar
 
 ### Step 7 — API monitor
+
 - Created `src/views/dev/ApiMonitor.vue` with status/endpoint/duration display
 - Exposes `window.__apiMonitor.record()` for use anywhere in the app
 - Route at `/dev/api` (name: `api-monitor`), not in NavBar
 
 ### API 監控注入
+
 - `finmind.ts`: axios 攔截器自動記錄每次請求 (URL, method, status, duration)
 - `apiCache.ts`: cache HIT/MISS 記錄到 `__apiMonitor`
 - `PerformanceMonitor.vue`: 掛載 `window.__perfMonitor` API
 
 ### Style 優化
+
 - FortuneLogViewer 全面改版：使用 `card` 類別與全站一致
 - 改用 ambert 主題色 (按鈕/焦點 ring)
 - 日期格式改為 `MM/DD 週W` 更簡潔
@@ -95,14 +131,17 @@
 - 改良統計列佈局、篩選控制項排列
 
 ### 強制自我檢查機制
+
 - `code-standards/SKILL.md` 新增 Step 0 強制檢查區塊 (單元測試→文件更新→Skill同步)
 
 ### 驗證結果
+
 - `vitest run`: ✅ 195 tests passed across 13 test files
 
 ## [2026-07-10] Step 8: Final UI Polish & Consistency Pass
 
 ### 頁面佈局完全統一
+
 - **所有主頁面外層**: `max-w-7xl mx-auto px-4 sm:px-6 lg:px-8` 整頁寬度
 - **所有頁面頂部 padding**: `py-6 sm:py-8 lg:py-12` 響應式垂直間距
 - **所有頁面標題 (h1)**: `text-xl sm:text-2xl lg:text-3xl font-bold text-white mb-1 sm:mb-2`
@@ -111,22 +150,26 @@
 - **所有頁面卡片**: 整頁寬度，無 max-w 限制（與 Dashboard、Analytics 一致）
 
 ### Dashboard.vue 更新
+
 - 頁面標題統一為響應式大小
 - 頂部 padding 統一為 `py-6 sm:py-8 lg:py-12`
 - 副標題顏色改為 `text-gray-400`（統一標準）
 
 ### Analytics.vue 更新
+
 - 頁面標題統一為響應式大小
 - 頂部 padding 統一為 `py-6 sm:py-8 lg:py-12`
 - 副標題顏色改為 `text-secondary`（保持一致）
 - 頭部間距改為 `mb-6 sm:mb-8`
 
 ### History.vue 優化
+
 - 移除外層 `space-y` wrapper div
 - 內容與外層同級（與 Dashboard、Analytics 保持一致）
 - FortuneLogViewer 組件直接放在 header 下方，整頁寬度
 
 ### Profile.vue 完全重新設計
+
 - 移除所有 `max-w-3xl mx-auto` 寬度限制
 - 卡片整頁寬度（與其他頁面一致）
 - 當前設定預覽卡片：`!py-3 !px-3 sm:!py-4 sm:!px-6 mb-5 sm:mb-6`
@@ -140,6 +183,7 @@
 - Select 欄位：`focus:ring-1 focus:ring-amber-500/50` 統一焦點樣式
 
 ### FortuneLogViewer.vue 驗證
+
 - 完全功能性和響應式確認
 - 日期格式：`MM/DD 週W` desktop 和 mobile 一致，mobile 使用 `text-[11px]`
 - 統計卡片：`!py-2.5 !px-3 sm:!py-3 sm:!px-6` 緊湊樣式
@@ -148,18 +192,21 @@
 - 分頁按鈕：mobile 全寬，desktop 內聯
 
 ### 統一的響應式系統
+
 - **頁面級**: `py-6 sm:py-8 lg:py-12` 垂直 padding，整頁寬度卡片
 - **卡片級**: `!py-3 !px-3 sm:!py-4 sm:!px-6` 或 `!py-4 !px-3 sm:!py-6 sm:!px-6` 根據內容
 - **表單級**: `space-y-4 sm:space-y-5` 元素間距，`px-2.5 sm:px-3 py-1.5 sm:py-2` 輸入框
 - **文字級**: `text-xs sm:text-sm lg:text-base` 標準漸進式調整
 
 ### 色彩系統統一
+
 - 主按鈕：`bg-amber-600 hover:bg-amber-500`
 - 焦點環：`focus:ring-1 focus:ring-amber-500/50`
 - 次級按鈕：`bg-white/10 hover:bg-white/20`
 - 徽章顏色：success emerald、warning amber、error rose
 
 ### 驗證結果
+
 - `npm run test`: ✅ 195/195 tests passed（100% 通過）
 - `npm run build`: ✅ Build 成功（11.68s）
 - `vue-tsc`: ✅ TypeScript 檢查通過（除了預存的舊錯誤）

--- a/src/components/FortuneLogViewer.vue
+++ b/src/components/FortuneLogViewer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { fortuneHistoryStore } from '@/services/fortuneStore'
+import { toLocalDateString } from '@/utils/date'
 import type { FortuneRecord, HistoryQueryOptions, HistoryStats } from '@/types/history'
 
 interface Props {
@@ -20,14 +21,19 @@ const total = ref(0)
 const pageIndex = ref(0)
 const loading = ref(false)
 const stats = ref<HistoryStats | null>(null)
+const filtersExpanded = ref(false)
+const showClearConfirm = ref(false)
 
 const now = new Date()
 const sixMonthsAgo = new Date(now)
 sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
 
+const defaultDateStart = toLocalDateString(sixMonthsAgo)
+const defaultDateEnd = toLocalDateString(now)
+
 const filterRecommendation = ref<FortuneRecord['recommendation'] | ''>('')
-const filterDateStart = ref(sixMonthsAgo.toISOString().split('T')[0])
-const filterDateEnd = ref(now.toISOString().split('T')[0])
+const filterDateStart = ref(defaultDateStart)
+const filterDateEnd = ref(defaultDateEnd)
 const searchText = ref('')
 
 const hasFilters = computed(
@@ -37,6 +43,28 @@ const hasFilters = computed(
     !!filterDateEnd.value ||
     !!searchText.value
 )
+
+const activeFilterTags = computed(() => {
+  const tags: { label: string; color: string }[] = []
+  if (filterRecommendation.value) {
+    const map = {
+      BUY: { label: '買入', color: 'bg-green-500/20 text-green-400' },
+      HOLD: { label: '持有', color: 'bg-yellow-500/20 text-yellow-400' },
+      SELL: { label: '賣出', color: 'bg-red-500/20 text-red-400' },
+    }
+    tags.push(map[filterRecommendation.value])
+  }
+  if (filterDateStart.value && filterDateStart.value !== defaultDateStart) {
+    tags.push({ label: filterDateStart.value.slice(5), color: 'bg-blue-500/20 text-blue-400' })
+  }
+  if (filterDateEnd.value && filterDateEnd.value !== defaultDateEnd) {
+    tags.push({ label: filterDateEnd.value.slice(5), color: 'bg-blue-500/20 text-blue-400' })
+  }
+  if (searchText.value) {
+    tags.push({ label: searchText.value, color: 'bg-purple-500/20 text-purple-400' })
+  }
+  return tags
+})
 
 const totalPages = computed(() => Math.ceil(total.value / props.pageSize))
 
@@ -51,6 +79,21 @@ const displayRecommendation = (
   return map[rec]
 }
 
+const elementColors: Record<string, string> = {
+  metal: '#9CA3AF',
+  wood: '#22C55E',
+  water: '#3B82F6',
+  fire: '#EF4444',
+  earth: '#A16207',
+}
+const elementLabels: Record<string, string> = {
+  metal: '金',
+  wood: '木',
+  water: '水',
+  fire: '火',
+  earth: '土',
+}
+
 const formatDate = (dateStr: string, mobile = false): string => {
   const d = new Date(dateStr + 'T00:00:00')
   const mm = String(d.getMonth() + 1).padStart(2, '0')
@@ -62,6 +105,12 @@ const formatDate = (dateStr: string, mobile = false): string => {
 
 const formatTime = (timestamp: number): string => {
   return new Date(timestamp).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' })
+}
+
+function getScoreColor(score: number): string {
+  if (score >= 70) return 'bg-emerald-500'
+  if (score >= 40) return 'bg-amber-500'
+  return 'bg-rose-500'
 }
 
 async function loadRecords() {
@@ -96,15 +145,21 @@ async function loadStats() {
 function applyFilters() {
   pageIndex.value = 0
   loadRecords()
+  filtersExpanded.value = false
 }
 
 function clearFilters() {
   filterRecommendation.value = ''
-  filterDateStart.value = ''
-  filterDateEnd.value = ''
+  filterDateStart.value = defaultDateStart
+  filterDateEnd.value = defaultDateEnd
   searchText.value = ''
   pageIndex.value = 0
   loadRecords()
+}
+
+function toggleRecommendation(value: FortuneRecord['recommendation']) {
+  filterRecommendation.value = filterRecommendation.value === value ? '' : value
+  applyFilters()
 }
 
 function nextPage() {
@@ -121,7 +176,16 @@ function prevPage() {
   }
 }
 
-async function clearAllHistory() {
+function openClearConfirm() {
+  showClearConfirm.value = true
+}
+
+function closeClearConfirm() {
+  showClearConfirm.value = false
+}
+
+async function confirmClearAll() {
+  showClearConfirm.value = false
   emit('confirmClear')
   await fortuneHistoryStore.clear()
   records.value = []
@@ -137,7 +201,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="space-y-5">
+  <div class="space-y-4 sm:space-y-5">
     <!-- Stats -->
     <div v-if="stats && stats.totalRecords > 0" class="card !py-2.5 !px-3 sm:!py-3 sm:!px-6">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1.5 sm:gap-2">
@@ -168,7 +232,7 @@ onMounted(async () => {
           </span>
           <button
             class="px-1.5 py-0.5 text-[10px] font-medium text-rose-400 hover:text-rose-300 border border-rose-800/50 rounded hover:bg-rose-900/20 transition-colors"
-            @click="clearAllHistory"
+            @click="openClearConfirm"
           >
             清除
           </button>
@@ -178,138 +242,322 @@ onMounted(async () => {
 
     <!-- Filters -->
     <div class="card !py-2.5 !px-3 sm:!py-3 sm:!px-6">
-      <div class="flex flex-col gap-2">
-        <div class="flex gap-2">
-          <input
-            v-model="searchText"
-            type="text"
-            placeholder="搜尋"
-            class="flex-1 min-w-0 px-2 py-1.5 sm:px-3 sm:py-2 text-xs sm:text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 transition-all"
-            @keyup.enter="applyFilters"
-          />
-          <button
-            class="px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-white bg-amber-600 hover:bg-amber-500 rounded-lg transition-colors shrink-0"
-            @click="applyFilters"
+      <!-- Mobile: collapsed summary bar -->
+      <div class="sm:hidden">
+        <button
+          class="w-full flex items-center justify-between gap-2"
+          @click="filtersExpanded = !filtersExpanded"
+        >
+          <div class="flex items-center gap-2 min-w-0 overflow-hidden">
+            <svg
+              class="w-4 h-4 text-gray-500 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
+              />
+            </svg>
+            <div v-if="activeFilterTags.length === 0" class="text-xs text-gray-500 truncate">
+              篩選條件
+            </div>
+            <div v-else class="flex items-center gap-1 overflow-hidden">
+              <span
+                v-for="(tag, i) in activeFilterTags"
+                :key="i"
+                class="px-1.5 py-0.5 text-[10px] rounded-full shrink-0"
+                :class="tag.color"
+              >
+                {{ tag.label }}
+              </span>
+            </div>
+          </div>
+          <svg
+            class="w-4 h-4 text-gray-500 shrink-0 transition-transform duration-200"
+            :class="{ 'rotate-180': filtersExpanded }"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            搜尋
-          </button>
-        </div>
-        <div class="flex flex-col sm:flex-row sm:items-center gap-1.5 sm:gap-3">
-          <div class="flex items-center gap-1.5">
-            <select
-              v-model="filterRecommendation"
-              class="px-2 py-1.5 text-xs sm:text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 transition-all"
-              @change="applyFilters"
-            >
-              <option value="">全部</option>
-              <option value="BUY">買入</option>
-              <option value="HOLD">持有</option>
-              <option value="SELL">賣出</option>
-            </select>
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+
+        <!-- Expanded filters (mobile) -->
+        <div v-show="filtersExpanded" class="mt-3 space-y-2 border-t border-white/5 pt-3">
+          <div class="flex gap-2">
+            <input
+              v-model="searchText"
+              type="text"
+              placeholder="搜尋"
+              class="flex-1 min-w-0 px-3 py-2 text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 transition-all"
+              @keyup.enter="applyFilters"
+            />
             <button
-              v-if="hasFilters"
-              class="sm:hidden text-xs text-gray-500 hover:text-gray-300 transition-colors"
-              @click="clearFilters"
+              class="px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-500 rounded-lg transition-colors shrink-0"
+              @click="applyFilters"
             >
-              清除
+              搜尋
             </button>
           </div>
-          <div class="flex items-center gap-1">
+
+          <!-- Chips -->
+          <div class="flex items-center gap-2">
+            <button
+              v-for="rec in ['BUY', 'HOLD', 'SELL'] as const"
+              :key="rec"
+              class="px-3 py-1.5 text-xs font-medium rounded-full border transition-all"
+              :class="
+                filterRecommendation === rec
+                  ? rec === 'BUY'
+                    ? 'bg-green-500/30 text-green-400 border-green-500/50'
+                    : rec === 'HOLD'
+                      ? 'bg-yellow-500/30 text-yellow-400 border-yellow-500/50'
+                      : 'bg-red-500/30 text-red-400 border-red-500/50'
+                  : 'bg-gray-800/40 text-gray-500 border-gray-700/60 hover:text-gray-300'
+              "
+              @click="toggleRecommendation(rec)"
+            >
+              {{ rec === 'BUY' ? '買入' : rec === 'HOLD' ? '持有' : '賣出' }}
+            </button>
+          </div>
+
+          <!-- Date range -->
+          <div class="flex items-center gap-2">
             <input
               v-model="filterDateStart"
               type="date"
-              class="flex-1 sm:w-auto px-1.5 sm:px-2 py-1.5 text-xs sm:text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 [color-scheme:dark] transition-all"
+              class="flex-1 px-2 py-2 text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 [color-scheme:dark] transition-all"
               @change="applyFilters"
             />
-            <span class="text-gray-600 shrink-0 text-xs sm:text-sm">~</span>
+            <span class="text-gray-600 shrink-0 text-sm">~</span>
             <input
               v-model="filterDateEnd"
               type="date"
-              class="flex-1 sm:w-auto px-1.5 sm:px-2 py-1.5 text-xs sm:text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 [color-scheme:dark] transition-all"
+              class="flex-1 px-2 py-2 text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 [color-scheme:dark] transition-all"
               @change="applyFilters"
             />
           </div>
+
           <button
             v-if="hasFilters"
-            class="hidden sm:inline text-xs text-gray-500 hover:text-gray-300 transition-colors"
+            class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
             @click="clearFilters"
           >
             清除篩選
           </button>
         </div>
       </div>
+
+      <!-- Desktop: always expanded -->
+      <div class="hidden sm:block">
+        <div class="flex flex-col gap-2">
+          <div class="flex gap-2">
+            <input
+              v-model="searchText"
+              type="text"
+              placeholder="搜尋"
+              class="flex-1 min-w-0 px-3 py-2 text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 transition-all"
+              @keyup.enter="applyFilters"
+            />
+            <button
+              class="px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-500 rounded-lg transition-colors shrink-0"
+              @click="applyFilters"
+            >
+              搜尋
+            </button>
+          </div>
+          <div class="flex items-center gap-3">
+            <!-- Desktop Chips -->
+            <div class="flex items-center gap-1.5">
+              <button
+                v-for="rec in ['BUY', 'HOLD', 'SELL'] as const"
+                :key="rec"
+                class="px-3 py-1.5 text-xs font-medium rounded-full border transition-all"
+                :class="
+                  filterRecommendation === rec
+                    ? rec === 'BUY'
+                      ? 'bg-green-500/30 text-green-400 border-green-500/50'
+                      : rec === 'HOLD'
+                        ? 'bg-yellow-500/30 text-yellow-400 border-yellow-500/50'
+                        : 'bg-red-500/30 text-red-400 border-red-500/50'
+                    : 'bg-gray-800/40 text-gray-500 border-gray-700/60 hover:text-gray-300'
+                "
+                @click="toggleRecommendation(rec)"
+              >
+                {{ rec === 'BUY' ? '買入' : rec === 'HOLD' ? '持有' : '賣出' }}
+              </button>
+            </div>
+            <div class="flex items-center gap-1">
+              <input
+                v-model="filterDateStart"
+                type="date"
+                class="w-auto px-2 py-1.5 text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 [color-scheme:dark] transition-all"
+                @change="applyFilters"
+              />
+              <span class="text-gray-600 shrink-0 text-sm">~</span>
+              <input
+                v-model="filterDateEnd"
+                type="date"
+                class="w-auto px-2 py-1.5 text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 [color-scheme:dark] transition-all"
+                @change="applyFilters"
+              />
+            </div>
+            <button
+              v-if="hasFilters"
+              class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              @click="clearFilters"
+            >
+              清除篩選
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
 
-    <!-- Records List -->
-    <div v-if="loading" class="card !py-12">
-      <div class="text-center text-gray-500">載入中...</div>
+    <!-- Loading skeleton -->
+    <div
+      v-if="loading"
+      class="space-y-4 sm:space-y-0 sm:divide-y sm:divide-gray-800/60 sm:overflow-hidden sm:card sm:!p-0"
+    >
+      <div
+        v-for="n in 5"
+        :key="n"
+        class="card sm:!rounded-none sm:!border-0 sm:!shadow-none !py-3 !px-3 sm:!py-4 sm:!px-6"
+      >
+        <!-- Mobile card skeleton -->
+        <div class="sm:hidden space-y-2">
+          <div class="flex items-center gap-2">
+            <div class="w-12 h-3 bg-white/5 rounded animate-pulse" />
+            <div class="w-7 h-7 bg-white/5 rounded-full animate-pulse" />
+            <div class="w-10 h-5 bg-white/5 rounded-full animate-pulse" />
+            <div class="ml-auto w-8 h-3 bg-white/5 rounded animate-pulse" />
+          </div>
+          <div class="flex items-center gap-1 pl-[52px]">
+            <div v-for="e in 5" :key="e" class="w-5 h-1 bg-white/5 rounded-full animate-pulse" />
+          </div>
+        </div>
+        <!-- Desktop list skeleton -->
+        <div class="hidden sm:flex items-center gap-4">
+          <div class="w-20 h-4 bg-white/5 rounded animate-pulse" />
+          <div class="w-9 h-9 bg-white/5 rounded-full animate-pulse" />
+          <div class="w-12 h-5 bg-white/5 rounded-full animate-pulse" />
+          <div class="flex items-center gap-1 ml-auto">
+            <div
+              v-for="e in 5"
+              :key="e"
+              class="w-1.5 bg-white/5 rounded-full animate-pulse"
+              :style="{ height: `${Math.max(4, 30 * 0.22)}px` }"
+            />
+          </div>
+          <div class="w-10 h-3 bg-white/5 rounded animate-pulse" />
+        </div>
+      </div>
     </div>
+
+    <!-- Empty state -->
     <div v-else-if="records.length === 0" class="card !py-12">
       <div class="text-center text-gray-500">
         {{ hasFilters ? '沒有符合條件的記錄' : '尚無歷史記錄' }}
       </div>
     </div>
-    <div v-else class="card !p-0 divide-y divide-gray-800/60 overflow-hidden">
+
+    <!-- Records List -->
+    <div v-else class="sm:card sm:!p-0 sm:divide-y sm:divide-gray-800/60 sm:overflow-hidden">
       <div
         v-for="record in records"
         :key="record.id"
-        class="px-3 sm:px-6 py-2.5 sm:py-4 hover:bg-white/[0.02] transition-colors cursor-default"
+        class="card !rounded-xl sm:!rounded-none sm:!border-0 sm:!shadow-none sm:!p-0 hover:bg-white/[0.02] transition-colors cursor-default"
       >
-        <div class="flex items-center gap-2 sm:gap-4 flex-wrap sm:flex-nowrap">
-          <div
-            class="text-[11px] sm:text-sm font-medium text-white/70 shrink-0 min-w-12 sm:min-w-0 leading-tight"
-          >
-            <span class="sm:hidden">{{ formatDate(record.date, true) }}</span>
-            <span class="hidden sm:inline">{{ formatDate(record.date) }}</span>
+        <!-- Mobile: card layout -->
+        <div class="sm:hidden">
+          <div class="flex items-center gap-2 mb-1.5">
+            <span class="text-[11px] font-medium text-white/70 leading-tight">
+              {{ formatDate(record.date, true) }}
+            </span>
+            <div
+              class="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
+              :class="getScoreColor(record.investmentScore)"
+            >
+              {{ record.investmentScore }}
+            </div>
+            <span
+              class="px-1.5 py-0.5 text-[10px] font-medium rounded-full shrink-0 leading-tight"
+              :class="displayRecommendation(record.recommendation).class"
+            >
+              {{ displayRecommendation(record.recommendation).text }}
+            </span>
+            <span class="text-[10px] text-gray-600 ml-auto leading-tight">
+              {{ formatTime(record.timestamp) }}
+            </span>
           </div>
+          <div class="flex items-center gap-1.5 pl-1">
+            <div v-for="(value, key) in record.elements" :key="key" class="flex items-end gap-0.5">
+              <div
+                class="w-5 h-1 rounded-full"
+                :style="{
+                  height: `${Math.max(4, value * 0.22)}px`,
+                  backgroundColor: elementColors[key],
+                }"
+              />
+              <span class="text-[8px] text-gray-600 leading-none">{{ elementLabels[key] }}</span>
+            </div>
+          </div>
+          <p
+            v-if="record.lunarSummary"
+            class="mt-1.5 text-[10px] text-gray-400/70 line-clamp-1 leading-relaxed"
+          >
+            {{ record.lunarSummary }}
+          </p>
+        </div>
+
+        <!-- Desktop: list layout -->
+        <div class="hidden sm:flex items-center gap-4 py-3 px-6">
+          <span class="text-sm font-medium text-white/70 min-w-20 leading-tight">
+            {{ formatDate(record.date) }}
+          </span>
           <div
-            class="w-7 h-7 sm:w-9 sm:h-9 rounded-full flex items-center justify-center text-[10px] sm:text-xs font-bold text-white shrink-0"
-            :class="
-              record.investmentScore >= 70
-                ? 'bg-emerald-500'
-                : record.investmentScore >= 40
-                  ? 'bg-amber-500'
-                  : 'bg-rose-500'
-            "
+            class="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-white shrink-0"
+            :class="getScoreColor(record.investmentScore)"
           >
             {{ record.investmentScore }}
           </div>
           <span
-            class="px-1.5 py-0.5 text-[10px] sm:text-xs font-medium rounded-full shrink-0 leading-tight"
+            class="px-2 py-0.5 text-xs font-medium rounded-full shrink-0 leading-tight"
             :class="displayRecommendation(record.recommendation).class"
           >
             {{ displayRecommendation(record.recommendation).text }}
           </span>
-          <div class="hidden sm:flex items-center gap-1 ml-auto">
+          <div class="flex items-center gap-1 ml-auto">
             <div
               v-for="(value, key) in record.elements"
               :key="key"
               class="w-1.5 rounded-full"
               :style="{
                 height: `${Math.max(4, value * 0.22)}px`,
-                backgroundColor:
-                  key === 'metal'
-                    ? '#9CA3AF'
-                    : key === 'wood'
-                      ? '#22C55E'
-                      : key === 'water'
-                        ? '#3B82F6'
-                        : key === 'fire'
-                          ? '#EF4444'
-                          : '#A16207',
+                backgroundColor: elementColors[key],
               }"
             />
           </div>
-          <span class="text-[10px] sm:text-xs text-gray-600 ml-auto leading-tight">
+          <span class="text-xs text-gray-600 leading-tight">
             {{ formatTime(record.timestamp) }}
           </span>
+          <p
+            v-if="record.lunarSummary"
+            class="absolute -bottom-0.5 left-[160px] text-xs text-gray-400/70 line-clamp-1 leading-relaxed"
+          >
+            {{ record.lunarSummary }}
+          </p>
         </div>
-        <p
-          v-if="record.lunarSummary"
-          class="mt-0.5 sm:mt-1 text-[10px] sm:text-xs text-gray-400/70 line-clamp-1 ml-12 sm:ml-0 leading-relaxed"
-        >
-          {{ record.lunarSummary }}
-        </p>
       </div>
     </div>
 
@@ -331,5 +579,46 @@ onMounted(async () => {
         下一頁 →
       </button>
     </div>
+
+    <!-- Clear confirmation dialog -->
+    <Teleport to="body">
+      <Transition name="fade">
+        <div
+          v-if="showClearConfirm"
+          class="fixed inset-0 z-50 flex items-center justify-center p-4"
+        >
+          <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeClearConfirm" />
+          <div class="card relative w-full max-w-sm !py-6 !px-6 z-10">
+            <h3 class="text-base font-semibold text-white mb-2">確認清除</h3>
+            <p class="text-sm text-gray-400 mb-5">確定要清除所有運勢歷史記錄嗎？此操作無法復原。</p>
+            <div class="flex justify-end gap-2">
+              <button
+                class="px-4 py-2 text-sm text-gray-400 hover:text-white bg-gray-800/40 hover:bg-gray-800/60 rounded-lg transition-colors"
+                @click="closeClearConfirm"
+              >
+                取消
+              </button>
+              <button
+                class="px-4 py-2 text-sm font-medium text-white bg-rose-600 hover:bg-rose-500 rounded-lg transition-colors"
+                @click="confirmClearAll"
+              >
+                確認清除
+              </button>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
   </div>
 </template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/services/finmind.ts
+++ b/src/services/finmind.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
 import type { ETFData, FinMindDataItem } from '@/types'
 import { apiCache, CacheKeyGenerator } from './apiCache'
+import { toLocalDateString } from '@/utils/date'
 
 // API 監控介面
 interface ApiMonitor {
@@ -117,7 +118,7 @@ export class FinMindService {
         const volume = Math.floor(Math.random() * 50000000) + 10000000
 
         const dataPoint = {
-          date: currentDate.toISOString().split('T')[0],
+          date: toLocalDateString(currentDate),
           open: Number(open.toFixed(2)),
           high: Number(high.toFixed(2)),
           low: Number(low.toFixed(2)),
@@ -208,10 +209,10 @@ export class FinMindService {
    */
   static async getRealTimePrice(): Promise<ETFData | null> {
     try {
-      const today = new Date().toISOString().split('T')[0]
+      const today = toLocalDateString(new Date())
       const yesterday = new Date()
       yesterday.setDate(yesterday.getDate() - 7) // 取最近7天的數據
-      const weekAgo = yesterday.toISOString().split('T')[0]
+      const weekAgo = toLocalDateString(yesterday)
 
       const data = await this.getETFData(weekAgo, today)
       // 返回最新的數據
@@ -221,7 +222,7 @@ export class FinMindService {
 
       // 如果無法取得數據，返回一個基本的模擬數據
       const mockPrice: ETFData = {
-        date: new Date().toISOString().split('T')[0],
+        date: toLocalDateString(new Date()),
         open: 132.5,
         high: 133.8,
         low: 131.9,

--- a/src/services/fortune.ts
+++ b/src/services/fortune.ts
@@ -1,6 +1,7 @@
 // @ts-expect-error - lunar-javascript doesn't have TypeScript definitions
 import { Solar } from 'lunar-javascript'
 import { perfMonitor } from '@/utils/performance'
+import { toLocalDateString } from '@/utils/date'
 
 import { fortuneHistoryStore } from '@/services/fortuneStore'
 import type {
@@ -122,7 +123,7 @@ export class FortuneService {
    * 獲取緩存鍵
    */
   private static getCacheKey(profile: UserProfile, date: Date): string {
-    const dateStr = date.toISOString().split('T')[0]
+    const dateStr = toLocalDateString(date)
     return `${profile.name}_${profile.birthDate}_${profile.birthTime}_${dateStr}`
   }
 
@@ -130,7 +131,7 @@ export class FortuneService {
    * 創建基於日期和用戶資料的種子 - 優化哈希算法
    */
   private static createSeed(date: Date, profile: UserProfile): number {
-    const dateStr = date.toISOString().split('T')[0].replace(/-/g, '')
+    const dateStr = toLocalDateString(date).replace(/-/g, '')
     const profileStr = `${profile.name}${profile.birthDate.replace(/-/g, '')}${profile.birthTime.replace(':', '')}`
 
     // 使用 FNV-1a 哈希算法，比簡單的 string hashing 更好
@@ -185,7 +186,7 @@ export class FortuneService {
       const recommendation = this.generateRecommendation(investmentScore, overallScore)
 
       const fortuneData: FortuneData = {
-        date: date.toISOString().split('T')[0],
+        date: toLocalDateString(date),
         overallScore: Math.round(overallScore),
         investmentScore: Math.round(investmentScore),
         recommendation,

--- a/src/services/integratedFortune.ts
+++ b/src/services/integratedFortune.ts
@@ -3,6 +3,7 @@ import { Solar } from 'lunar-javascript'
 import { lunarService } from '@/services/lunar'
 import { TaiwanStockService } from './taiwanStock'
 import { fortuneHistoryStore } from '@/services/fortuneStore'
+import { toLocalDateString } from '@/utils/date'
 import type { LunarData } from '@/services/lunar'
 import type { PersonalBaZi, ElementsEnergy } from '@/types'
 
@@ -173,7 +174,7 @@ export class IntegratedFortuneService {
     profile: UserProfileCompat,
     date: Date = new Date()
   ): Promise<IntegratedFortuneData> {
-    const cacheKey = `${profile.birthDate}-${date.toISOString().split('T')[0]}`
+    const cacheKey = `${profile.birthDate}-${toLocalDateString(date)}`
 
     if (this.cache.has(cacheKey)) {
       return this.cache.get(cacheKey)!
@@ -644,7 +645,7 @@ export class IntegratedFortuneService {
     fortuneHistoryStore
       .append({
         id: Date.now(),
-        date: fortune.date.toISOString().split('T')[0],
+        date: toLocalDateString(fortune.date),
         timestamp: Date.now(),
         overallScore: fortune.overallScore,
         investmentScore: fortune.investmentScore,

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -3,6 +3,7 @@ import { ref, computed, shallowRef } from 'vue'
 import { lunarService } from '@/services/lunar'
 import { IntegratedFortuneService } from '@/services/integratedFortune'
 import { FinMindService } from '@/services/finmind'
+import { toLocalDateString } from '@/utils/date'
 import type { LunarData, InvestmentAdvice } from '@/services/lunar'
 import type { IntegratedFortuneData, UserProfileCompat } from '@/services/integratedFortune'
 import type { ETFData } from '@/types'
@@ -197,8 +198,8 @@ export const useDashboardStore = defineStore('dashboard', () => {
       }
 
       // 計算日期範圍
-      const endDate = new Date().toISOString().split('T')[0]
-      const startDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+      const endDate = toLocalDateString(new Date())
+      const startDate = toLocalDateString(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000))
 
       try {
         const data = await FinMindService.getETFData(startDate, endDate)

--- a/src/tests/fortuneLogViewer.test.ts
+++ b/src/tests/fortuneLogViewer.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 
-// Mock data must be defined inside vi.mock factory to avoid hoisting issues
 vi.mock('@/services/fortuneStore', () => {
   const mockRecords = [
     {
@@ -39,40 +38,46 @@ vi.mock('@/services/fortuneStore', () => {
     },
   ]
 
-  return {
-    fortuneHistoryStore: {
-      init: vi.fn().mockResolvedValue(undefined),
-      query: vi
-        .fn()
-        .mockResolvedValue({ records: mockRecords, total: 3, pageIndex: 0, pageSize: 10 }),
-      getStats: vi.fn().mockResolvedValue({
-        totalRecords: 3,
-        dateRange: { earliest: '2024-01-15', latest: '2024-01-17' },
-        averageScore: 50,
-        recommendationDistribution: { BUY: 1, HOLD: 1, SELL: 1 },
-      }),
-      clear: vi.fn().mockResolvedValue(undefined),
-    },
+  const store = {
+    init: vi.fn().mockResolvedValue(undefined),
+    query: vi
+      .fn()
+      .mockResolvedValue({ records: mockRecords, total: 3, pageIndex: 0, pageSize: 10 }),
+    getStats: vi.fn().mockResolvedValue({
+      totalRecords: 3,
+      dateRange: { earliest: '2024-01-15', latest: '2024-01-17' },
+      averageScore: 50,
+      recommendationDistribution: { BUY: 1, HOLD: 1, SELL: 1 },
+    }),
+    clear: vi.fn().mockResolvedValue(undefined),
   }
+
+  return { fortuneHistoryStore: store }
 })
 
 import FortuneLogViewer from '@/components/FortuneLogViewer.vue'
+import { fortuneHistoryStore } from '@/services/fortuneStore'
 
 describe('FortuneLogViewer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
   })
 
   it('should display stats when loaded', async () => {
     const wrapper = mount(FortuneLogViewer)
-    await vi.dynamicImportSettled()
+    await flushPromises()
 
     expect(wrapper.text()).toContain('共 3 筆')
   })
 
   it('should display records list', async () => {
     const wrapper = mount(FortuneLogViewer)
-    await vi.dynamicImportSettled()
+    await flushPromises()
 
     expect(wrapper.text()).toContain('買入')
     expect(wrapper.text()).toContain('持有')
@@ -80,34 +85,87 @@ describe('FortuneLogViewer', () => {
     expect(wrapper.text()).toContain('今日財運亨通')
   })
 
-  it('should show recommendation badges', async () => {
+  it('should show recommendation badges in records', async () => {
     const wrapper = mount(FortuneLogViewer)
-    await vi.dynamicImportSettled()
+    await flushPromises()
 
-    const badges = wrapper.findAll('.rounded-full')
-    const buyBadge = badges.filter(b => b.text().trim() === '買入')
-    expect(buyBadge.length).toBeGreaterThan(0)
-    expect(buyBadge[0].classes()).toContain('bg-green-500/20')
+    const buyBadges = wrapper.findAll('.bg-green-500\\/20')
+    expect(buyBadges.length).toBeGreaterThan(0)
+    expect(buyBadges[0].text().trim()).toBe('買入')
   })
 
-  it('should display filter controls', async () => {
+  it('should display filter chip buttons instead of select', async () => {
     const wrapper = mount(FortuneLogViewer)
-    await vi.dynamicImportSettled()
+    await flushPromises()
 
     expect(wrapper.find('input[placeholder="搜尋"]').exists()).toBe(true)
-    expect(wrapper.find('select').exists()).toBe(true)
-    expect(wrapper.findAll('input[type="date"]').length).toBe(2)
+    expect(wrapper.find('select').exists()).toBe(false)
+
+    const chipTexts = ['買入', '持有', '賣出']
+    for (const text of chipTexts) {
+      const chip = wrapper.findAll('button').find(b => b.text().trim() === text)
+      expect(chip).toBeDefined()
+    }
   })
 
-  it('should emit confirmClear when clear button clicked', async () => {
+  it('should show confirmation dialog when clear button clicked', async () => {
     const wrapper = mount(FortuneLogViewer)
-    await vi.dynamicImportSettled()
+    await flushPromises()
 
     const clearBtn = wrapper.findAll('button').find(b => b.text().includes('清除'))
     expect(clearBtn).toBeDefined()
     await clearBtn!.trigger('click')
-    await new Promise(r => setTimeout(r, 10))
+    await flushPromises()
+
+    const dialogText = document.body.textContent || ''
+    expect(dialogText).toContain('確認清除')
+    expect(dialogText).toContain('此操作無法復原')
+    expect(wrapper.emitted('confirmClear')).toBeFalsy()
+  })
+
+  it('should emit confirmClear after confirming in dialog', async () => {
+    const wrapper = mount(FortuneLogViewer)
+    await flushPromises()
+
+    const clearBtn = wrapper.findAll('button').find(b => b.text().includes('清除'))
+    await clearBtn!.trigger('click')
+    await flushPromises()
+
+    const confirmBtns = document.body.querySelectorAll('button')
+    const confirmBtn = Array.from(confirmBtns).find(b => b.textContent?.includes('確認清除'))
+    expect(confirmBtn).toBeDefined()
+    confirmBtn!.click()
+    await flushPromises()
 
     expect(wrapper.emitted('confirmClear')).toBeTruthy()
+  })
+
+  it('should close dialog when cancel clicked', async () => {
+    const wrapper = mount(FortuneLogViewer)
+    await flushPromises()
+
+    const clearBtn = wrapper.findAll('button').find(b => b.text().includes('清除'))
+    await clearBtn!.trigger('click')
+    await flushPromises()
+
+    expect(document.body.textContent).toContain('確認清除')
+
+    const cancelBtns = document.body.querySelectorAll('button')
+    const cancelBtn = Array.from(cancelBtns).find(b => b.textContent?.trim() === '取消')
+    cancelBtn!.click()
+    await flushPromises()
+
+    expect(document.body.textContent).not.toContain('確認清除')
+  })
+
+  it('should show skeleton loading state', async () => {
+    vi.mocked(fortuneHistoryStore.query).mockImplementation(() => new Promise(() => {}) as never)
+
+    const wrapper = mount(FortuneLogViewer)
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    const skeletons = wrapper.findAll('.animate-pulse')
+    expect(skeletons.length).toBeGreaterThan(0)
   })
 })

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,10 @@
+/**
+ * 將 Date 物件轉換為本地時區的 YYYY-MM-DD 格式字串。
+ * 避免 toISOString() 將本地時間轉成 UTC 導致日期偏移。
+ */
+export function toLocalDateString(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}

--- a/src/views/Analytics.vue
+++ b/src/views/Analytics.vue
@@ -5,6 +5,7 @@ import { useAnalyticsStore } from '@/stores/analytics'
 import { useUserStore } from '@/stores/user'
 import { useTheme } from '@/composables/useTheme'
 import { FinMindService } from '@/services/finmind'
+import { toLocalDateString } from '@/utils/date'
 
 // Lazy load components
 const PriceChart = defineAsyncComponent({
@@ -85,9 +86,9 @@ const loadAnalyticsData = async () => {
 
   try {
     // 根據當前選擇的時間段載入對應的數據
-    const endDate = new Date().toISOString().split('T')[0]
+    const endDate = toLocalDateString(new Date())
     const days = analyticsStore.getPeriodDays(selectedPeriod.value)
-    const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+    const startDate = toLocalDateString(new Date(Date.now() - days * 24 * 60 * 60 * 1000))
 
     // 載入 ETF 數據
     const etfData = await FinMindService.getETFData(startDate, endDate)


### PR DESCRIPTION
- 手機版記錄從水平列表改為獨立卡片佈局
- 篩選面板手機版預設收合，顯示 active filter tags 摘要
- <select> 下拉框改為 filter chips（買入/持有/賣出）
- 新增清除確認對話框（Teleport + 遮罩）
- 載入中改為 skeleton pulse 動畫
- 修復 toISOString() 在 UTC+8 時區下日期偏移一天的 bug
- 新增 utils/date.ts toLocalDateString() 工具函數
- 修復 fortune.ts、integratedFortune.ts、finmind.ts、dashboard.ts、Analytics.vue
- fortuneLogViewer 測試從 5 個擴充為 8 個