### PR TITLE
feat: 引擎結果寫入歷史 + 運勢記錄卡片重設計 + Bug Fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 - **Step 8**: Final UI Polish & Consistency Pass — All 4 main pages unified layout (full-width cards, responsive spacing), 195 tests pass ✅
 - **Step 9**: 命理引擎架構 (MetaphysicsEngine interface + registry, ClassicFortuneEngine, BaziTenGodsEngine, ZiWeiEngine, FengShuiEngine, EngineSettingsCard)
 - **Step 10**: 引擎整合至核心 — registry 設定同步 localStorage，引擎加權分數融入 integratedFortune 投資/整體/財運分數，EngineSettingsCard 儲存觸發 Dashboard 即時重算，Profile 雙欄重構 ✅
+- **Step 11**: 引擎結果寫入歷史 + 運勢記錄卡片重設計 + Bug Fixes — `recordFortuneHistory()` 保存 enginesResults + engineWeightedScore，FortuneLogViewer mobile/desktop 卡片佈局全面翻新，修復 classic.ts 缺少 engineId 導致 Analytics 權重 0%，EngineSettingsCard 新增權重加總指示器 ✅
 
 ## Routes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [2026-07-11] 引擎結果寫入歷史 + 運勢記錄卡片重設計 + 修復
+
+### Bug Fix: classic.ts 缺少 engineId
+
+- `ClassicFortuneEngine.calculate()` 回傳值補上 `engineId: 'classic'`
+- 修復 Analytics 頁面經典命理權重顯示為 0% 的問題
+
+### Bug Fix: Analytics 頁面 hardcoded 權重
+
+- `ENGINE_WEIGHTS` 改為從 `metaphysicsRegistry` 動態讀取，反映使用者即時調整
+
+### EngineSettingsCard 權重加總指示器
+
+- 新增權重加總條圖 + 狀態文字（100% 完美 / 接近 / 偏差）
+- 條圖 0-150% 範圍，超過 150% 截斷顯示
+- 顏色：綠色 100%、琥珀色 80-120%、紅色超出範圍
+
+### 歷史記錄引擎資料 (`src/services/integratedFortune.ts`, `src/types/history.ts`)
+
+- `EngineResultSummary` 型別：engineId、engineName、score、weight
+- `FortuneRecord` 新增 `enginesResults` 與 `engineWeightedScore` 欄位
+- `recordFortuneHistory()` 計算時從 registry 取得各引擎權重，一併寫入歷史
+
+### FortuneLogViewer 卡片佈局重設計 (`src/components/FortuneLogViewer.vue`)
+
+**Mobile：**
+
+- 分數圓形放大至 11×11，日期/時間/建議徽章左側排列
+- 五行能量條改為垂直長條 + 底部標籤（scale 0.28）
+- 引擎分數改為個別 chips（圖標 + 分數 + 權重%），加權分數獨立 badge
+- 農曆摘要行數從 1 行改為 2 行
+
+**Desktop：**
+
+- 三欄佈局：左側分數圓形 + 建議徽章 | 中間日期/五行/摘要 | 右側引擎分數
+- 五行能量條加高（scale 0.3），底部標籤
+- 引擎分數 chips + 加權分數置於右側
+- 農曆摘要置於中欄底部
+
+---
+
 ## [2026-07-11] 命理引擎整合至核心運勢計算 + Profile 雙欄重構
 
 ### 命理引擎整合 (`src/services/engines/`)

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ Lucky50/
 │   │   ├── charts/      # 圖表組件
 │   │   │   ├── PriceChart.vue          # 價格走勢圖
 │   │   │   ├── VolumeChart.vue         # 成交量圖
-│   │   │   └── ElementRadarChart.vue   # 五行雷達圖
+│   │   │   ├── ElementRadarChart.vue   # 五行雷達圖
+│   │   │   └── EngineScoresChart.vue   # 引擎分數橫條圖
 │   │   ├── three/       # Three.js 3D 組件
 │   │   │   ├── Stock3DVisualization.vue
 │   │   │   ├── Fortune3DVisualization.vue

--- a/src/components/EngineSettingsCard.vue
+++ b/src/components/EngineSettingsCard.vue
@@ -6,15 +6,12 @@
     </h3>
 
     <p class="text-sm text-gray-400 mb-4">
-      調整各命理引擎的啟用狀態與權重，影響運勢計算結果
+      每個引擎的「權重」代表它在綜合運勢中佔的比例。例如經典命理 30%、八字十神
+      25%，表示前者影響力略大於後者。
     </p>
 
     <div class="space-y-4">
-      <div
-        v-for="engine in engines"
-        :key="engine.id"
-        class="p-4 bg-white/5 rounded-lg"
-      >
+      <div v-for="engine in engines" :key="engine.id" class="p-4 bg-white/5 rounded-lg">
         <div class="flex items-center justify-between mb-2">
           <div class="flex items-center gap-2">
             <span class="text-lg">{{ engine.icon }}</span>
@@ -43,10 +40,7 @@
           </button>
         </div>
 
-        <div
-          v-if="engine.enabled"
-          class="mt-3"
-        >
+        <div v-if="engine.enabled" class="mt-3">
           <div class="flex items-center justify-between text-xs text-gray-500 mb-1">
             <span>權重</span>
             <span class="text-amber-400">{{ engine.weight }}%</span>
@@ -59,7 +53,7 @@
             step="5"
             class="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer accent-amber-500"
             @input="e => updateWeight(engine.id, Number((e.target as HTMLInputElement).value))"
-          >
+          />
           <div class="flex justify-between text-xs text-gray-500 mt-1">
             <span>0%</span>
             <span>50%</span>
@@ -67,6 +61,38 @@
           </div>
         </div>
       </div>
+    </div>
+
+    <!-- 權重加總指示器 -->
+    <div class="mt-5 p-3 bg-white/5 rounded-lg">
+      <div class="flex items-center justify-between mb-1.5">
+        <span class="text-xs text-gray-400">啟用引擎的權重加總</span>
+        <span class="text-sm font-bold" :class="weightStatus.color">{{ weightStatus.label }}</span>
+      </div>
+      <div class="w-full h-2 bg-white/10 rounded-full overflow-hidden">
+        <div
+          class="h-full rounded-full transition-all duration-300"
+          :class="weightStatus.bar"
+          :style="{ width: `${Math.min(totalWeight, 150) / 1.5}%` }"
+        />
+      </div>
+      <div class="flex justify-between text-[10px] text-gray-600 mt-1">
+        <span>0%</span>
+        <span :class="totalWeight === 100 ? 'text-green-500 font-bold' : 'text-gray-600'"
+          >100%</span
+        >
+        <span>150%</span>
+      </div>
+      <p class="text-[11px] text-gray-500 mt-2 leading-relaxed">
+        <template v-if="totalWeight === 100"> 權重加總恰好為 100%，各引擎按比例貢獻。 </template>
+        <template v-else-if="totalWeight > 0 && totalWeight < 100">
+          加總不足 100% 時，系統會自動正規化（按比例放大），不影響排序結果。
+        </template>
+        <template v-else-if="totalWeight > 100">
+          加總超過 100% 時，系統會自動正規化（按比例縮小），不影響排序結果。
+        </template>
+        <template v-else> 所有引擎已關閉，運勢將使用基礎分數。 </template>
+      </p>
     </div>
 
     <!-- 重設按鈕 -->
@@ -85,17 +111,12 @@
       </button>
     </div>
 
-    <div
-      v-if="saved"
-      class="mt-2 text-sm text-green-400"
-    >
-      設定已儲存
-    </div>
+    <div v-if="saved" class="mt-2 text-sm text-green-400">設定已儲存</div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { IntegratedFortuneService } from '@/services/integratedFortune'
 
 interface EngineConfig {
@@ -150,6 +171,34 @@ const engines = ref<EngineConfig[]>([
 ])
 
 const saved = ref(false)
+
+const totalWeight = computed(() =>
+  engines.value.filter(e => e.enabled).reduce((sum, e) => sum + e.weight, 0)
+)
+
+const weightStatus = computed(() => {
+  const t = totalWeight.value
+  if (t === 100)
+    return {
+      label: '100% — 完美',
+      color: 'text-green-400',
+      bar: 'bg-green-500',
+      ring: 'ring-green-500/30',
+    }
+  if (t >= 80 && t <= 120)
+    return {
+      label: `${t}% — 接近`,
+      color: 'text-amber-400',
+      bar: 'bg-amber-500',
+      ring: 'ring-amber-500/30',
+    }
+  return {
+    label: `${t}% — 偏差`,
+    color: 'text-rose-400',
+    bar: 'bg-rose-500',
+    ring: 'ring-rose-500/30',
+  }
+})
 
 function loadSettings() {
   try {

--- a/src/components/FortuneLogViewer.vue
+++ b/src/components/FortuneLogViewer.vue
@@ -47,6 +47,20 @@ const elementLabels: Record<string, string> = {
   earth: '土',
 }
 
+const engineIcons: Record<string, string> = {
+  classic: '🏮',
+  'bazi-ten-gods': '🔮',
+  'zi-wei': '⭐',
+  'feng-shui': '🧭',
+}
+
+const engineColors: Record<string, string> = {
+  classic: 'text-amber-400',
+  'bazi-ten-gods': 'text-purple-400',
+  'zi-wei': 'text-blue-400',
+  'feng-shui': 'text-emerald-400',
+}
+
 // ── 響應式狀態 ──
 const records = ref<FortuneRecord[]>([])
 const total = ref(0)
@@ -247,10 +261,7 @@ function getScoreColor(score: number): string {
 <template>
   <div class="space-y-4 sm:space-y-5">
     <!-- Stats -->
-    <div
-      v-if="stats && stats.totalRecords > 0"
-      class="card !py-2.5 !px-3 sm:!py-3 sm:!px-6"
-    >
+    <div v-if="stats && stats.totalRecords > 0" class="card !py-2.5 !px-3 sm:!py-3 sm:!px-6">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1.5 sm:gap-2">
         <div class="flex flex-wrap items-center gap-2 text-[11px] sm:text-sm">
           <div class="flex items-center gap-1">
@@ -273,10 +284,7 @@ function getScoreColor(score: number): string {
         <div class="flex items-center gap-2">
           <span class="text-gray-600 text-[11px]">
             共 {{ stats.totalRecords }} 筆
-            <span
-              v-if="stats.dateRange"
-              class="hidden sm:inline"
-            >
+            <span v-if="stats.dateRange" class="hidden sm:inline">
               · {{ stats.dateRange.earliest }} ~ {{ stats.dateRange.latest }}
             </span>
           </span>
@@ -312,16 +320,10 @@ function getScoreColor(score: number): string {
                 d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
               />
             </svg>
-            <div
-              v-if="activeFilterTags.length === 0"
-              class="text-xs text-gray-500 truncate"
-            >
+            <div v-if="activeFilterTags.length === 0" class="text-xs text-gray-500 truncate">
               篩選條件
             </div>
-            <div
-              v-else
-              class="flex items-center gap-1 overflow-hidden"
-            >
+            <div v-else class="flex items-center gap-1 overflow-hidden">
               <span
                 v-for="(tag, i) in activeFilterTags"
                 :key="i"
@@ -349,10 +351,7 @@ function getScoreColor(score: number): string {
         </button>
 
         <!-- Expanded filters (mobile) -->
-        <div
-          v-show="filtersExpanded"
-          class="mt-3 space-y-2 border-t border-white/5 pt-3"
-        >
+        <div v-show="filtersExpanded" class="mt-3 space-y-2 border-t border-white/5 pt-3">
           <div class="flex gap-2">
             <input
               v-model="searchText"
@@ -360,7 +359,7 @@ function getScoreColor(score: number): string {
               placeholder="搜尋"
               class="flex-1 min-w-0 px-3 py-2 text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 transition-all"
               @keyup.enter="applyFilters"
-            >
+            />
             <button
               class="px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-500 rounded-lg transition-colors shrink-0"
               @click="applyFilters"
@@ -441,7 +440,7 @@ function getScoreColor(score: number): string {
               placeholder="搜尋"
               class="flex-1 min-w-0 px-3 py-2 text-sm bg-gray-800/40 border border-gray-700/60 rounded-lg text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 transition-all"
               @keyup.enter="applyFilters"
-            >
+            />
             <button
               class="px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-500 rounded-lg transition-colors shrink-0"
               @click="applyFilters"
@@ -530,11 +529,7 @@ function getScoreColor(score: number): string {
             <div class="ml-auto w-8 h-3 bg-white/5 rounded animate-pulse" />
           </div>
           <div class="flex items-center gap-1 pl-[52px]">
-            <div
-              v-for="e in 5"
-              :key="e"
-              class="w-5 h-1 bg-white/5 rounded-full animate-pulse"
-            />
+            <div v-for="e in 5" :key="e" class="w-5 h-1 bg-white/5 rounded-full animate-pulse" />
           </div>
         </div>
         <!-- Desktop list skeleton -->
@@ -556,117 +551,182 @@ function getScoreColor(score: number): string {
     </div>
 
     <!-- Empty state -->
-    <div
-      v-else-if="records.length === 0"
-      class="card !py-12"
-    >
+    <div v-else-if="records.length === 0" class="card !py-12">
       <div class="text-center text-gray-500">
         {{ hasFilters ? '沒有符合條件的記錄' : '尚無歷史記錄' }}
       </div>
     </div>
 
     <!-- Records List -->
-    <div
-      v-else
-      class="sm:card sm:!p-0 sm:divide-y sm:divide-gray-800/60 sm:overflow-hidden"
-    >
+    <div v-else class="space-y-3 sm:space-y-0 sm:divide-y sm:divide-gray-800/60 sm:overflow-hidden">
       <div
         v-for="record in records"
         :key="record.id"
-        class="card !rounded-xl sm:!rounded-none sm:!border-0 sm:!shadow-none sm:!p-0 hover:bg-white/[0.02] transition-colors cursor-default"
+        class="card sm:!rounded-none sm:!border-0 sm:!shadow-none sm:!p-4 hover:bg-white/[0.02] transition-colors"
       >
         <!-- Mobile: card layout -->
-        <div class="sm:hidden">
-          <div class="flex items-center gap-2 mb-1.5">
-            <span class="text-[11px] font-medium text-white/70 leading-tight">
-              {{ formatDate(record.date, true) }}
-            </span>
+        <div class="sm:hidden space-y-2">
+          <!-- Top row: score + date + time -->
+          <div class="flex items-center gap-2.5">
             <div
-              class="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
+              class="w-11 h-11 rounded-full flex items-center justify-center text-sm font-bold text-white shrink-0"
               :class="getScoreColor(record.investmentScore)"
             >
               {{ record.investmentScore }}
             </div>
-            <span
-              class="px-1.5 py-0.5 text-[10px] font-medium rounded-full shrink-0 leading-tight"
-              :class="displayRecommendation(record.recommendation).class"
-            >
-              {{ displayRecommendation(record.recommendation).text }}
-            </span>
-            <span class="text-[10px] text-gray-600 ml-auto leading-tight">
-              {{ formatTime(record.timestamp) }}
-            </span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="text-sm font-semibold text-white">
+                  {{ formatDate(record.date, true) }}
+                </span>
+                <span class="text-[10px] text-gray-500">
+                  {{ formatTime(record.timestamp) }}
+                </span>
+              </div>
+              <span
+                class="inline-block mt-0.5 px-2 py-0.5 text-[10px] font-medium rounded-full leading-tight"
+                :class="displayRecommendation(record.recommendation).class"
+              >
+                {{ displayRecommendation(record.recommendation).text }}
+              </span>
+            </div>
           </div>
-          <div class="flex items-center gap-1.5 pl-1">
+          <!-- 五行能量條 -->
+          <div class="flex items-end gap-1 pl-1">
             <div
               v-for="(value, key) in record.elements"
               :key="key"
-              class="flex items-end gap-0.5"
+              class="flex flex-col items-center gap-0.5"
             >
               <div
-                class="w-5 h-1 rounded-full"
+                class="w-6 rounded-full"
                 :style="{
-                  height: `${Math.max(4, value * 0.22)}px`,
+                  height: `${Math.max(6, value * 0.28)}px`,
                   backgroundColor: elementColors[key],
                 }"
               />
-              <span class="text-[8px] text-gray-600 leading-none">{{ elementLabels[key] }}</span>
+              <span class="text-[9px] text-gray-500 leading-none">{{ elementLabels[key] }}</span>
             </div>
           </div>
+          <!-- 引擎分數 -->
+          <div
+            v-if="record.enginesResults && record.enginesResults.length > 0"
+            class="flex items-center gap-1.5 flex-wrap"
+          >
+            <span
+              v-for="engine in record.enginesResults"
+              :key="engine.engineId"
+              class="inline-flex items-center gap-1 px-1.5 py-0.5 bg-white/5 rounded text-[10px]"
+            >
+              <span>{{ engineIcons[engine.engineId] || '⚙️' }}</span>
+              <span class="font-medium" :class="engineColors[engine.engineId] || 'text-gray-400'">{{
+                engine.score
+              }}</span>
+              <span class="text-gray-600">{{ engine.weight }}%</span>
+            </span>
+            <span
+              v-if="record.engineWeightedScore != null"
+              class="inline-flex items-center px-1.5 py-0.5 bg-amber-500/10 rounded text-[10px] font-medium text-amber-400"
+            >
+              加權 {{ record.engineWeightedScore }}
+            </span>
+          </div>
+          <!-- 農曆摘要 -->
           <p
             v-if="record.lunarSummary"
-            class="mt-1.5 text-[10px] text-gray-400/70 line-clamp-1 leading-relaxed"
+            class="text-[11px] text-gray-400/70 line-clamp-2 leading-relaxed"
           >
             {{ record.lunarSummary }}
           </p>
         </div>
 
-        <!-- Desktop: list layout -->
-        <div class="hidden sm:flex items-center gap-4 py-3 px-6">
-          <span class="text-sm font-medium text-white/70 min-w-20 leading-tight">
-            {{ formatDate(record.date) }}
-          </span>
-          <div
-            class="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold text-white shrink-0"
-            :class="getScoreColor(record.investmentScore)"
-          >
-            {{ record.investmentScore }}
-          </div>
-          <span
-            class="px-2 py-0.5 text-xs font-medium rounded-full shrink-0 leading-tight"
-            :class="displayRecommendation(record.recommendation).class"
-          >
-            {{ displayRecommendation(record.recommendation).text }}
-          </span>
-          <div class="flex items-center gap-1 ml-auto">
+        <!-- Desktop: card layout -->
+        <div class="hidden sm:block">
+          <div class="flex items-start gap-4">
+            <!-- Left: Score circle -->
+            <div class="flex flex-col items-center gap-1 shrink-0">
+              <div
+                class="w-12 h-12 rounded-full flex items-center justify-center text-sm font-bold text-white"
+                :class="getScoreColor(record.investmentScore)"
+              >
+                {{ record.investmentScore }}
+              </div>
+              <span
+                class="px-2 py-0.5 text-[11px] font-medium rounded-full leading-tight"
+                :class="displayRecommendation(record.recommendation).class"
+              >
+                {{ displayRecommendation(record.recommendation).text }}
+              </span>
+            </div>
+            <!-- Center: date + elements + summary -->
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 mb-1">
+                <span class="text-sm font-semibold text-white">
+                  {{ formatDate(record.date) }}
+                </span>
+                <span class="text-xs text-gray-500">
+                  {{ formatTime(record.timestamp) }}
+                </span>
+              </div>
+              <!-- 五行能量 -->
+              <div class="flex items-end gap-1.5 mb-1">
+                <div
+                  v-for="(value, key) in record.elements"
+                  :key="key"
+                  class="flex flex-col items-center gap-0.5"
+                >
+                  <div
+                    class="w-7 rounded-full"
+                    :style="{
+                      height: `${Math.max(6, value * 0.3)}px`,
+                      backgroundColor: elementColors[key],
+                    }"
+                  />
+                  <span class="text-[10px] text-gray-500 leading-none">{{
+                    elementLabels[key]
+                  }}</span>
+                </div>
+              </div>
+              <p
+                v-if="record.lunarSummary"
+                class="text-xs text-gray-400/70 line-clamp-1 leading-relaxed"
+              >
+                {{ record.lunarSummary }}
+              </p>
+            </div>
+            <!-- Right: engine scores -->
             <div
-              v-for="(value, key) in record.elements"
-              :key="key"
-              class="w-1.5 rounded-full"
-              :style="{
-                height: `${Math.max(4, value * 0.22)}px`,
-                backgroundColor: elementColors[key],
-              }"
-            />
+              v-if="record.enginesResults && record.enginesResults.length > 0"
+              class="flex flex-col items-end gap-1 shrink-0"
+            >
+              <div class="flex items-center gap-1.5">
+                <span
+                  v-for="engine in record.enginesResults"
+                  :key="engine.engineId"
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 bg-white/5 rounded text-[11px]"
+                >
+                  <span>{{ engineIcons[engine.engineId] || '⚙️' }}</span>
+                  <span
+                    class="font-medium"
+                    :class="engineColors[engine.engineId] || 'text-gray-400'"
+                    >{{ engine.score }}</span
+                  >
+                </span>
+              </div>
+              <span
+                v-if="record.engineWeightedScore != null"
+                class="text-[11px] text-amber-400/80 font-medium"
+              >
+                加權 {{ record.engineWeightedScore }}
+              </span>
+            </div>
           </div>
-          <span class="text-xs text-gray-600 leading-tight">
-            {{ formatTime(record.timestamp) }}
-          </span>
-          <p
-            v-if="record.lunarSummary"
-            class="absolute -bottom-0.5 left-[160px] text-xs text-gray-400/70 line-clamp-1 leading-relaxed"
-          >
-            {{ record.lunarSummary }}
-          </p>
         </div>
       </div>
     </div>
 
     <!-- Pagination -->
-    <div
-      v-if="totalPages > 1"
-      class="flex items-center justify-between"
-    >
+    <div v-if="totalPages > 1" class="flex items-center justify-between">
       <button
         :disabled="pageIndex === 0"
         class="px-3 py-1.5 text-sm text-gray-500 hover:text-white bg-gray-800/20 hover:bg-gray-800/50 rounded-lg disabled:opacity-25 disabled:cursor-not-allowed transition-all"
@@ -691,17 +751,10 @@ function getScoreColor(score: number): string {
           v-if="showClearConfirm"
           class="fixed inset-0 z-50 flex items-center justify-center p-4"
         >
-          <div
-            class="absolute inset-0 bg-black/60 backdrop-blur-sm"
-            @click="closeClearConfirm"
-          />
+          <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeClearConfirm" />
           <div class="card relative w-full max-w-sm !py-6 !px-6 z-10">
-            <h3 class="text-base font-semibold text-white mb-2">
-              確認清除
-            </h3>
-            <p class="text-sm text-gray-400 mb-5">
-              確定要清除所有運勢歷史記錄嗎？此操作無法復原。
-            </p>
+            <h3 class="text-base font-semibold text-white mb-2">確認清除</h3>
+            <p class="text-sm text-gray-400 mb-5">確定要清除所有運勢歷史記錄嗎？此操作無法復原。</p>
             <div class="flex justify-end gap-2">
               <button
                 class="px-4 py-2 text-sm text-gray-400 hover:text-white bg-gray-800/40 hover:bg-gray-800/60 rounded-lg transition-colors"

--- a/src/services/engines/classic.ts
+++ b/src/services/engines/classic.ts
@@ -22,6 +22,7 @@ export class ClassicFortuneEngine implements MetaphysicsEngine {
     // 經典引擎不產生額外分數，它的貢獻已直接在 IntegratedFortuneService 中計算
     // 這裡只提供基礎建議
     return {
+      engineId: 'classic',
       engineName: this.name,
       score: 50,
       advice: ['經典五行分析已納入計算'],

--- a/src/services/integratedFortune.ts
+++ b/src/services/integratedFortune.ts
@@ -809,6 +809,15 @@ export class IntegratedFortuneService {
   ): void {
     const dateStr = profile.birthDate.replace(/-/g, '')
     const profileHash = `${profile.name}_${dateStr}`.length.toString(36)
+
+    // 將引擎結果轉為精簡摘要存入歷史（含權重）
+    const enginesResults = fortune.enginesResults?.map(r => ({
+      engineId: r.engineId ?? '',
+      engineName: r.engineName,
+      score: r.score,
+      weight: metaphysicsRegistry.getEngineById(r.engineId ?? '')?.getWeight() ?? 0,
+    }))
+
     fortuneHistoryStore
       .append({
         id: Date.now(),
@@ -819,6 +828,8 @@ export class IntegratedFortuneService {
         recommendation: fortune.recommendation === 'OBSERVE' ? 'HOLD' : fortune.recommendation,
         elements: fortune.elements,
         lunarSummary: fortune.advice,
+        enginesResults,
+        engineWeightedScore: fortune.engineWeightedScore,
         userProfileHash: profileHash,
       })
       .catch(() => {})

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -4,6 +4,20 @@
  */
 
 /**
+ * 引擎分析摘要（存入歷史用）
+ */
+export interface EngineResultSummary {
+  /** 引擎 ID */
+  engineId: string
+  /** 引擎名稱 */
+  engineName: string
+  /** 引擎分數 (0-100) */
+  score: number
+  /** 引擎權重 (%) */
+  weight: number
+}
+
+/**
  * 運勢歷史記錄
  */
 export interface FortuneRecord {
@@ -29,6 +43,10 @@ export interface FortuneRecord {
   }
   /** 農民曆摘要 */
   lunarSummary?: string
+  /** 命理引擎分析結果 */
+  enginesResults?: EngineResultSummary[]
+  /** 引擎加權分數 */
+  engineWeightedScore?: number
   /** 用戶資料雜湊值（用於區分不同用戶的記錄） */
   userProfileHash: string
 }

--- a/src/views/Analytics.vue
+++ b/src/views/Analytics.vue
@@ -6,6 +6,7 @@ import { useUserStore } from '@/stores/user'
 import { useTheme } from '@/composables/useTheme'
 import { FinMindService } from '@/services/finmind'
 import { toLocalDateString } from '@/utils/date'
+import { metaphysicsRegistry } from '@/services/engines'
 
 // ── 元件 ──
 const PriceChart = defineAsyncComponent({
@@ -86,12 +87,13 @@ const ENGINE_LABELS: Record<string, string> = {
   'zi-wei': '紫微斗數',
   'feng-shui': '風水方位',
 }
-const ENGINE_WEIGHTS: Record<string, number> = {
-  classic: 30,
-  'bazi-ten-gods': 25,
-  'zi-wei': 20,
-  'feng-shui': 15,
-}
+const ENGINE_WEIGHTS = computed(() => {
+  const weights: Record<string, number> = {}
+  for (const id of ['classic', 'bazi-ten-gods', 'zi-wei', 'feng-shui']) {
+    weights[id] = metaphysicsRegistry.getEngineById(id)?.getWeight() ?? 0
+  }
+  return weights
+})
 
 const engineResults = computed(() => dashboardStore.integratedFortune?.enginesResults ?? [])
 const engineWeightedScore = computed(
@@ -159,9 +161,7 @@ onMounted(() => {
           </div>
           <!-- 全局時間區間選擇器 -->
           <div class="flex flex-col sm:items-end gap-2 w-full sm:w-auto">
-            <div class="text-sm text-secondary text-center sm:text-right">
-              分析時間區間
-            </div>
+            <div class="text-sm text-secondary text-center sm:text-right">分析時間區間</div>
             <div class="grid grid-cols-3 sm:flex gap-2 w-full sm:w-auto">
               <button
                 v-for="period in periods"
@@ -204,9 +204,7 @@ onMounted(() => {
         <div class="card mb-6">
           <div class="flex items-center gap-3 mb-4">
             <div class="w-3 h-3 bg-gold-500 rounded-full" />
-            <h2 class="text-xl font-semibold text-primary">
-              農民曆智慧策略
-            </h2>
+            <h2 class="text-xl font-semibold text-primary">農民曆智慧策略</h2>
             <div class="text-sm text-gold-400 bg-gold-500/10 px-3 py-1 rounded-full">
               優於市場表現
             </div>
@@ -217,9 +215,7 @@ onMounted(() => {
               <div class="text-2xl sm:text-3xl font-bold text-green-400 mb-1">
                 +{{ backtestResults.lunar.annualReturn }}%
               </div>
-              <div class="text-sm text-secondary mb-1">
-                年化報酬率
-              </div>
+              <div class="text-sm text-secondary mb-1">年化報酬率</div>
               <div class="text-xs text-green-400/60">
                 vs 市場 {{ statistics.annualReturn >= 0 ? '+' : '' }}{{ statistics.annualReturn }}%
               </div>
@@ -229,36 +225,24 @@ onMounted(() => {
               <div class="text-2xl sm:text-3xl font-bold text-blue-400 mb-1">
                 +{{ backtestResults.lunar.totalReturn }}%
               </div>
-              <div class="text-sm text-secondary mb-1">
-                {{ selectedPeriod }}累積報酬
-              </div>
-              <div class="text-xs text-blue-400/60">
-                期間總收益
-              </div>
+              <div class="text-sm text-secondary mb-1">{{ selectedPeriod }}累積報酬</div>
+              <div class="text-xs text-blue-400/60">期間總收益</div>
             </div>
 
             <div class="text-center">
               <div class="text-2xl sm:text-3xl font-bold text-purple-400 mb-1">
                 {{ backtestResults.lunar.sharpeRatio }}
               </div>
-              <div class="text-sm text-secondary mb-1">
-                夏普比率
-              </div>
-              <div class="text-xs text-purple-400/60">
-                風險調整後收益
-              </div>
+              <div class="text-sm text-secondary mb-1">夏普比率</div>
+              <div class="text-xs text-purple-400/60">風險調整後收益</div>
             </div>
 
             <div class="text-center">
               <div class="text-2xl sm:text-3xl font-bold text-gold-400 mb-1">
                 {{ backtestResults.lunar.winRate }}%
               </div>
-              <div class="text-sm text-secondary mb-1">
-                交易勝率
-              </div>
-              <div class="text-xs text-gold-400/60">
-                成功交易比例
-              </div>
+              <div class="text-sm text-secondary mb-1">交易勝率</div>
+              <div class="text-xs text-gold-400/60">成功交易比例</div>
             </div>
           </div>
         </div>
@@ -271,14 +255,14 @@ onMounted(() => {
           >
             <div class="flex items-center gap-2 mb-3">
               <div class="w-2 h-2 bg-gold-500 rounded-full" />
-              <h3 class="font-semibold text-gold-400">
-                農民曆智慧策略
-              </h3>
+              <h3 class="font-semibold text-gold-400">農民曆智慧策略</h3>
             </div>
             <div class="space-y-2 text-sm">
               <div class="flex justify-between">
                 <span class="text-secondary">年化報酬</span>
-                <span class="text-green-400 font-semibold">+{{ backtestResults.lunar.annualReturn }}%</span>
+                <span class="text-green-400 font-semibold"
+                  >+{{ backtestResults.lunar.annualReturn }}%</span
+                >
               </div>
               <div class="flex justify-between">
                 <span class="text-secondary">最大回撤</span>
@@ -295,14 +279,14 @@ onMounted(() => {
           <div class="card border border-white/10">
             <div class="flex items-center gap-2 mb-3">
               <div class="w-2 h-2 bg-blue-500 rounded-full" />
-              <h3 class="font-semibold text-blue-400">
-                買入持有策略
-              </h3>
+              <h3 class="font-semibold text-blue-400">買入持有策略</h3>
             </div>
             <div class="space-y-2 text-sm">
               <div class="flex justify-between">
                 <span class="text-secondary">年化報酬</span>
-                <span class="text-green-400 font-semibold">+{{ backtestResults.buyHold.annualReturn }}%</span>
+                <span class="text-green-400 font-semibold"
+                  >+{{ backtestResults.buyHold.annualReturn }}%</span
+                >
               </div>
               <div class="flex justify-between">
                 <span class="text-secondary">最大回撤</span>
@@ -319,14 +303,14 @@ onMounted(() => {
           <div class="card border border-white/10">
             <div class="flex items-center gap-2 mb-3">
               <div class="w-2 h-2 bg-green-500 rounded-full" />
-              <h3 class="font-semibold text-green-400">
-                定期定額策略
-              </h3>
+              <h3 class="font-semibold text-green-400">定期定額策略</h3>
             </div>
             <div class="space-y-2 text-sm">
               <div class="flex justify-between">
                 <span class="text-secondary">年化報酬</span>
-                <span class="text-green-400 font-semibold">+{{ backtestResults.dca.annualReturn }}%</span>
+                <span class="text-green-400 font-semibold"
+                  >+{{ backtestResults.dca.annualReturn }}%</span
+                >
               </div>
               <div class="flex justify-between">
                 <span class="text-secondary">最大回撤</span>
@@ -368,16 +352,11 @@ onMounted(() => {
       </div>
 
       <!-- 命理引擎分析 -->
-      <div
-        v-if="hasEngineData"
-        class="card mb-8"
-      >
+      <div v-if="hasEngineData" class="card mb-8">
         <div class="mb-6">
           <div class="flex items-center gap-3 mb-2">
             <div class="w-3 h-3 bg-purple-500 rounded-full" />
-            <h2 class="text-xl font-semibold text-primary">
-              命理引擎分析
-            </h2>
+            <h2 class="text-xl font-semibold text-primary">命理引擎分析</h2>
             <div class="text-sm text-gold-400 bg-gold-500/10 px-3 py-1 rounded-full">
               加權分數 {{ engineWeightedScore }}
             </div>
@@ -389,11 +368,7 @@ onMounted(() => {
 
         <!-- 引擎分數長條圖 -->
         <div class="bg-white/5 rounded-lg p-4 mb-6">
-          <EngineScoresChart
-            :results="engineResults"
-            :weights="ENGINE_WEIGHTS"
-            :is-dark="isDark"
-          />
+          <EngineScoresChart :results="engineResults" :weights="ENGINE_WEIGHTS" :is-dark="isDark" />
         </div>
 
         <!-- 各引擎詳情卡片 -->
@@ -427,19 +402,15 @@ onMounted(() => {
               </div>
               <div class="flex justify-between">
                 <span class="text-secondary">權重</span>
-                <span class="text-secondary">{{ ENGINE_WEIGHTS[result.engineId ?? ''] ?? 0 }}%</span>
+                <span class="text-secondary"
+                  >{{ ENGINE_WEIGHTS[result.engineId ?? ''] ?? 0 }}%</span
+                >
               </div>
-              <div
-                v-if="result.confidence != null"
-                class="flex justify-between"
-              >
+              <div v-if="result.confidence != null" class="flex justify-between">
                 <span class="text-secondary">信心度</span>
                 <span class="text-secondary">{{ (result.confidence * 100).toFixed(0) }}%</span>
               </div>
-              <div
-                v-if="result.advice?.length"
-                class="pt-2 border-t border-white/10"
-              >
+              <div v-if="result.advice?.length" class="pt-2 border-t border-white/10">
                 <p class="text-secondary text-xs leading-relaxed">
                   {{ result.advice[0] }}
                 </p>
@@ -454,9 +425,7 @@ onMounted(() => {
         <!-- 價格走勢圖 -->
         <div class="card">
           <div class="mb-6">
-            <h2 class="text-xl font-semibold text-primary mb-2">
-              價格走勢分析
-            </h2>
+            <h2 class="text-xl font-semibold text-primary mb-2">價格走勢分析</h2>
             <p class="text-sm text-secondary">
               基於 <span class="text-gold-400 font-medium">{{ selectedPeriod }}</span>
               歷史數據的價格與成交量分析
@@ -472,10 +441,7 @@ onMounted(() => {
                 <span>載入 {{ selectedPeriod }} 數據中...</span>
               </div>
             </div>
-            <PriceChart
-              :etf-data="filteredEtfData"
-              :is-dark="isDark"
-            />
+            <PriceChart :etf-data="filteredEtfData" :is-dark="isDark" />
           </div>
         </div>
 
@@ -483,9 +449,7 @@ onMounted(() => {
           <!-- 成交量分析 -->
           <div class="card">
             <div class="mb-6">
-              <h2 class="text-xl font-semibold text-primary mb-2">
-                成交量分析
-              </h2>
+              <h2 class="text-xl font-semibold text-primary mb-2">成交量分析</h2>
               <p class="text-sm text-secondary">
                 <span class="text-gold-400 font-medium">{{ selectedPeriod }}</span>
                 期間的成交量變化趨勢
@@ -514,12 +478,8 @@ onMounted(() => {
                 ]"
               >
                 <div class="text-center">
-                  <p class="text-secondary mb-2">
-                    無 {{ selectedPeriod }} 成交量數據
-                  </p>
-                  <p class="text-secondary text-sm opacity-70">
-                    請檢查數據連線或選擇其他時間段
-                  </p>
+                  <p class="text-secondary mb-2">無 {{ selectedPeriod }} 成交量數據</p>
+                  <p class="text-secondary text-sm opacity-70">請檢查數據連線或選擇其他時間段</p>
                 </div>
               </div>
             </div>
@@ -528,9 +488,7 @@ onMounted(() => {
           <!-- 技術指標摘要 -->
           <div class="card">
             <div class="mb-6">
-              <h2 class="text-xl font-semibold text-primary mb-2">
-                技術指標摘要
-              </h2>
+              <h2 class="text-xl font-semibold text-primary mb-2">技術指標摘要</h2>
               <p class="text-sm text-secondary">
                 基於 <span class="text-gold-400 font-medium">{{ selectedPeriod }}</span>
                 數據的技術分析指標
@@ -544,9 +502,7 @@ onMounted(() => {
                 ]"
               >
                 <div>
-                  <div class="text-sm text-secondary">
-                    RSI (相對強弱指數)
-                  </div>
+                  <div class="text-sm text-secondary">RSI (相對強弱指數)</div>
                   <div class="text-lg font-semibold text-yellow-400">
                     {{ technicalIndicators.rsi.toFixed(1) }}
                   </div>
@@ -578,9 +534,7 @@ onMounted(() => {
                 ]"
               >
                 <div>
-                  <div class="text-sm text-secondary">
-                    MACD
-                  </div>
+                  <div class="text-sm text-secondary">MACD</div>
                   <div
                     class="text-lg font-semibold"
                     :class="technicalIndicators.macd >= 0 ? 'text-green-400' : 'text-red-400'"
@@ -602,9 +556,7 @@ onMounted(() => {
               </div>
 
               <div :class="['p-4 rounded-lg', isDark ? 'bg-gray-800/50' : 'bg-slate-100/80']">
-                <div class="text-sm text-secondary mb-2">
-                  布林通道位置
-                </div>
+                <div class="text-sm text-secondary mb-2">布林通道位置</div>
                 <div class="flex justify-center">
                   <div
                     :class="[
@@ -628,15 +580,15 @@ onMounted(() => {
               </div>
 
               <div :class="['p-4 rounded-lg', isDark ? 'bg-gray-800/50' : 'bg-slate-100/80']">
-                <div class="text-sm text-secondary mb-2">
-                  KD 指標
-                </div>
+                <div class="text-sm text-secondary mb-2">KD 指標</div>
                 <div class="flex justify-between">
                   <div>
                     <span class="text-blue-400">K: {{ technicalIndicators.kd.k.toFixed(1) }}</span>
                   </div>
                   <div>
-                    <span class="text-purple-400">D: {{ technicalIndicators.kd.d.toFixed(1) }}</span>
+                    <span class="text-purple-400"
+                      >D: {{ technicalIndicators.kd.d.toFixed(1) }}</span
+                    >
                   </div>
                   <div
                     :class="[
@@ -659,9 +611,7 @@ onMounted(() => {
         <!-- 運勢與績效相關性 -->
         <div class="card">
           <div class="mb-6">
-            <h2 class="text-xl font-semibold text-primary mb-2">
-              運勢與投資績效相關性
-            </h2>
+            <h2 class="text-xl font-semibold text-primary mb-2">運勢與投資績效相關性</h2>
             <p class="text-sm text-secondary">
               分析 <span class="text-gold-400 font-medium">{{ selectedPeriod }}</span>
               期間運勢指標與實際投資表現的關聯度
@@ -669,9 +619,7 @@ onMounted(() => {
           </div>
           <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <div class="space-y-4">
-              <h3 class="text-lg font-medium text-gold-400">
-                運勢分數分佈
-              </h3>
+              <h3 class="text-lg font-medium text-gold-400">運勢分數分佈</h3>
               <div class="space-y-2">
                 <div class="flex justify-between">
                   <span class="text-secondary">高運勢 (80+)</span>
@@ -689,9 +637,7 @@ onMounted(() => {
             </div>
 
             <div class="space-y-4">
-              <h3 class="text-lg font-medium text-gold-400">
-                平均報酬率
-              </h3>
+              <h3 class="text-lg font-medium text-gold-400">平均報酬率</h3>
               <div class="space-y-2">
                 <div class="flex justify-between">
                   <span class="text-secondary">高運勢日</span>
@@ -717,27 +663,31 @@ onMounted(() => {
             </div>
 
             <div class="space-y-4">
-              <h3 class="text-lg font-medium text-gold-400">
-                成功率
-              </h3>
+              <h3 class="text-lg font-medium text-gold-400">成功率</h3>
               <div class="space-y-2">
                 <div class="flex justify-between">
                   <span class="text-secondary">BUY 建議</span>
-                  <span class="text-green-400">{{
-                    Math.min(Math.max(Math.round(75 + statistics.sharpeRatio * 5), 60), 90)
-                  }}%</span>
+                  <span class="text-green-400"
+                    >{{
+                      Math.min(Math.max(Math.round(75 + statistics.sharpeRatio * 5), 60), 90)
+                    }}%</span
+                  >
                 </div>
                 <div class="flex justify-between">
                   <span class="text-secondary">HOLD 建議</span>
-                  <span class="text-yellow-400">{{
-                    Math.min(Math.max(Math.round(65 + statistics.sharpeRatio * 3), 55), 80)
-                  }}%</span>
+                  <span class="text-yellow-400"
+                    >{{
+                      Math.min(Math.max(Math.round(65 + statistics.sharpeRatio * 3), 55), 80)
+                    }}%</span
+                  >
                 </div>
                 <div class="flex justify-between">
                   <span class="text-secondary">SELL 建議</span>
-                  <span class="text-red-400">{{
-                    Math.min(Math.max(Math.round(70 + statistics.sharpeRatio * 2), 60), 85)
-                  }}%</span>
+                  <span class="text-red-400"
+                    >{{
+                      Math.min(Math.max(Math.round(70 + statistics.sharpeRatio * 2), 60), 85)
+                    }}%</span
+                  >
                 </div>
               </div>
             </div>


### PR DESCRIPTION
- FortuneRecord 新增 enginesResults 與 engineWeightedScore 欄位
- recordFortuneHistory() 從 registry 取得權重一併寫入歷史
- FortuneLogViewer mobile/desktop 卡片佈局全面翻新（大圓分數、五行能量條、引擎分數 chips、加權 badge、農曆摘要）
- 修復 classic.ts 缺少 engineId 導致 Analytics 權重顯示 0%
- Analytics.vue ENGINE_WEIGHTS 改從 registry 動態讀取
- EngineSettingsCard 新增權重加總指示器（進度條 + 動態說明文字）
- 更新 CHANGELOG、README、AGENTS